### PR TITLE
Fix missing batch parameter in forked(batch:filter:map:)

### DIFF
--- a/Sources/Fork/Extensions/Sequence+BatchedForkedArray.swift
+++ b/Sources/Fork/Extensions/Sequence+BatchedForkedArray.swift
@@ -27,7 +27,7 @@ extension Sequence where Element: Sendable {
         filter: @Sendable @escaping (Element) async throws -> Bool,
         map: @Sendable @escaping (Element) async throws -> Output
     ) async throws -> [Output] {
-        try await fork(filter: filter, map: map).output()
+        try await fork(batch: batch, filter: filter, map: map).output()
     }
 
     /// Create a ``BatchedForkedArray`` from the current `Sequence` and get the Output Array


### PR DESCRIPTION
The forked(batch:filter:map:) function was ignoring the batch parameter
and calling the non-batched fork(filter:map:) instead. This caused users
to get ForkedArray behavior instead of BatchedForkedArray behavior when
using this convenience method.