### PR TITLE
Remove redundant StrictConcurrency experimental feature flag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,17 +20,11 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "Fork",
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            name: "Fork"
         ),
         .testTarget(
             name: "ForkTests",
-            dependencies: ["Fork"],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            dependencies: ["Fork"]
         )
     ]
 )


### PR DESCRIPTION
## Summary

- Remove `.enableExperimentalFeature("StrictConcurrency")` from both the `Fork` target and `ForkTests` test target in `Package.swift`
- Since `swiftSettings` contained only this single flag, the entire `swiftSettings` parameter is removed from both targets

## Rationale

The package uses `swift-tools-version: 6.0`, which enables strict concurrency checking by default. The `.enableExperimentalFeature("StrictConcurrency")` setting is therefore redundant and unnecessary. Removing it reduces noise in the package manifest without any change in behavior.

## Test plan

- [ ] Verify the package still builds successfully (`swift build`)
- [ ] Verify tests still pass (`swift test`)
- [ ] Confirm strict concurrency is still enforced (it is, by virtue of Swift 6.0 language mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)