### PR TITLE
Rename async* to concurrent* Sequence extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The above code will now download all three photos at the same time. When all the
 Now, using Fork we could simplify this to just a couple of lines!
 
 ```swift
-let photos = try await photoNames.asyncMap(downloadPhoto(named:))
+let photos = try await photoNames.concurrentMap(downloadPhoto(named:))
 show(photos)
 ```
 

--- a/Sources/Fork/BatchedForkedArray.swift
+++ b/Sources/Fork/BatchedForkedArray.swift
@@ -46,7 +46,7 @@ public struct BatchedForkedArray<Value: Sendable, Output: Sendable>: Sendable {
         var batchedOutput: [[Output]] = []
 
         for batch in batchedArray {
-            let batchedValues = try await batch.asyncFilter(filter).asyncMap(map)
+            let batchedValues = try await batch.concurrentFilter(filter).concurrentMap(map)
 
             batchedOutput.append(batchedValues)
         }
@@ -63,7 +63,7 @@ public struct BatchedForkedArray<Value: Sendable, Output: Sendable>: Sendable {
                 do {
                     for batch in batchedArray {
                         try Task.checkCancellation()
-                        let batchedValues = try await batch.asyncFilter(filter).asyncMap(map)
+                        let batchedValues = try await batch.concurrentFilter(filter).concurrentMap(map)
                         continuation.yield(batchedValues)
                     }
                     continuation.finish()

--- a/Sources/Fork/Extensions/Sequence+BatchedForkedArray.swift
+++ b/Sources/Fork/Extensions/Sequence+BatchedForkedArray.swift
@@ -38,35 +38,73 @@ extension Sequence where Element: Sendable {
         try await forked(batch: batch, filter: { _ in true }, map: map)
     }
 
-    /// Returns an array containing the results of mapping the given closure over the sequence’s elements.
-    public func asyncMap<Output: Sendable>(
+    /// Concurrently maps the given closure over the sequence's elements in batches, returning an array of results.
+    public func concurrentMap<Output: Sendable>(
         batch: UInt,
         _ transform: @Sendable @escaping (Element) async throws -> Output
     ) async throws -> [Output] {
         try await fork(batch: batch, map: transform).output()
     }
 
-    /// Returns an array containing the results, that aren't nil, of mapping the given closure over the sequence’s elements.
-    public func asyncCompactMap<Output: Sendable>(
+    /// Concurrently maps the given closure over the sequence's elements in batches, returning an array of non-nil results.
+    public func concurrentCompactMap<Output: Sendable>(
         batch: UInt,
         _ transform: @Sendable @escaping (Element) async throws -> Output?
     ) async throws -> [Output] {
         try await fork(batch: batch, map: transform).output().compactMap { $0 }
     }
 
-    /// Returns an array containing only the true results from the given closure over the sequence’s elements.
-    public func asyncFilter(
+    /// Concurrently filters the sequence's elements in batches using the given closure.
+    public func concurrentFilter(
         batch: UInt,
         _ isIncluded: @Sendable @escaping (Element) async throws -> Bool
     ) async throws -> [Element] {
         try await fork(batch: batch, filter: isIncluded, map: identity).output()
     }
 
+    /// Concurrently calls the given closure for each element in the sequence, processing in batches.
+    public func concurrentForEach(
+        batch: UInt,
+        _ transform: @Sendable @escaping (Element) async throws -> Void
+    ) async throws {
+        _ = try await concurrentMap(batch: batch, transform)
+    }
+
+    // MARK: - Deprecated
+
+    /// Returns an array containing the results of mapping the given closure over the sequence's elements.
+    @available(*, deprecated, renamed: "concurrentMap(batch:_:)")
+    public func asyncMap<Output: Sendable>(
+        batch: UInt,
+        _ transform: @Sendable @escaping (Element) async throws -> Output
+    ) async throws -> [Output] {
+        try await concurrentMap(batch: batch, transform)
+    }
+
+    /// Returns an array containing the results, that aren't nil, of mapping the given closure over the sequence's elements.
+    @available(*, deprecated, renamed: "concurrentCompactMap(batch:_:)")
+    public func asyncCompactMap<Output: Sendable>(
+        batch: UInt,
+        _ transform: @Sendable @escaping (Element) async throws -> Output?
+    ) async throws -> [Output] {
+        try await concurrentCompactMap(batch: batch, transform)
+    }
+
+    /// Returns an array containing only the true results from the given closure over the sequence's elements.
+    @available(*, deprecated, renamed: "concurrentFilter(batch:_:)")
+    public func asyncFilter(
+        batch: UInt,
+        _ isIncluded: @Sendable @escaping (Element) async throws -> Bool
+    ) async throws -> [Element] {
+        try await concurrentFilter(batch: batch, isIncluded)
+    }
+
     /// Calls the given closure for each of the elements in the Sequence. This function uses ``BatchedForkedArray`` and will be parallelized when possible.
+    @available(*, deprecated, renamed: "concurrentForEach(batch:_:)")
     public func asyncForEach(
         batch: UInt,
         _ transform: @Sendable @escaping (Element) async throws -> Void
     ) async throws {
-        _ = try await asyncMap(batch: batch, transform)
+        try await concurrentForEach(batch: batch, transform)
     }
 }

--- a/Sources/Fork/Extensions/Sequence+ForkedArray.swift
+++ b/Sources/Fork/Extensions/Sequence+ForkedArray.swift
@@ -10,14 +10,14 @@ extension Sequence where Element: Sendable {
             map: map
         )
     }
-    
+
     /// Create a ``ForkedArray`` from the current `Sequence`
     public func fork<Output: Sendable>(
         map: @Sendable @escaping (Element) async throws -> Output
     ) -> ForkedArray<Element, Output> {
         fork(filter: { _ in true }, map: map)
     }
-    
+
     /// Create a ``ForkedArray`` from the current `Sequence` and get the Output Array
     public func forked<Output: Sendable>(
         filter: @Sendable @escaping (Element) async throws -> Bool,
@@ -25,39 +25,73 @@ extension Sequence where Element: Sendable {
     ) async throws -> [Output] {
         try await fork(filter: filter, map: map).output()
     }
-    
+
     /// Create a ``ForkedArray`` from the current `Sequence` and get the Output Array
     public func forked<Output: Sendable>(
         map: @Sendable @escaping (Element) async throws -> Output
     ) async throws -> [Output] {
         try await forked(filter: { _ in true }, map: map)
     }
-    
-    /// Returns an array containing the results of mapping the given closure over the sequence’s elements.
-    public func asyncMap<Output: Sendable>(
+
+    /// Concurrently maps the given closure over the sequence's elements, returning an array of results.
+    public func concurrentMap<Output: Sendable>(
         _ transform: @Sendable @escaping (Element) async throws -> Output
     ) async throws -> [Output] {
         try await fork(map: transform).output()
     }
-    
-    /// Returns an array containing the results, that aren't nil, of mapping the given closure over the sequence’s elements.
-    public func asyncCompactMap<Output: Sendable>(
+
+    /// Concurrently maps the given closure over the sequence's elements, returning an array of non-nil results.
+    public func concurrentCompactMap<Output: Sendable>(
         _ transform: @Sendable @escaping (Element) async throws -> Output?
     ) async throws -> [Output] {
         try await fork(map: transform).output().compactMap { $0 }
     }
-    
-    /// Returns an array containing only the true results from the given closure over the sequence’s elements.
-    public func asyncFilter(
+
+    /// Concurrently filters the sequence's elements using the given closure.
+    public func concurrentFilter(
         _ isIncluded: @Sendable @escaping (Element) async throws -> Bool
     ) async throws -> [Element] {
         try await fork(filter: isIncluded, map: identity).output()
     }
-    
+
+    /// Concurrently calls the given closure for each element in the sequence.
+    public func concurrentForEach(
+        _ transform: @Sendable @escaping (Element) async throws -> Void
+    ) async throws {
+        _ = try await concurrentMap(transform)
+    }
+
+    // MARK: - Deprecated
+
+    /// Returns an array containing the results of mapping the given closure over the sequence's elements.
+    @available(*, deprecated, renamed: "concurrentMap")
+    public func asyncMap<Output: Sendable>(
+        _ transform: @Sendable @escaping (Element) async throws -> Output
+    ) async throws -> [Output] {
+        try await concurrentMap(transform)
+    }
+
+    /// Returns an array containing the results, that aren't nil, of mapping the given closure over the sequence's elements.
+    @available(*, deprecated, renamed: "concurrentCompactMap")
+    public func asyncCompactMap<Output: Sendable>(
+        _ transform: @Sendable @escaping (Element) async throws -> Output?
+    ) async throws -> [Output] {
+        try await concurrentCompactMap(transform)
+    }
+
+    /// Returns an array containing only the true results from the given closure over the sequence's elements.
+    @available(*, deprecated, renamed: "concurrentFilter")
+    public func asyncFilter(
+        _ isIncluded: @Sendable @escaping (Element) async throws -> Bool
+    ) async throws -> [Element] {
+        try await concurrentFilter(isIncluded)
+    }
+
     /// Calls the given closure for each of the elements in the Sequence. This function uses ``ForkedArray`` and will be parallelized when possible.
+    @available(*, deprecated, renamed: "concurrentForEach")
     public func asyncForEach(
         _ transform: @Sendable @escaping (Element) async throws -> Void
     ) async throws {
-        _ = try await asyncMap(transform)
+        try await concurrentForEach(transform)
     }
 }

--- a/Tests/ForkTests/BatchedForkedArrayTests.swift
+++ b/Tests/ForkTests/BatchedForkedArrayTests.swift
@@ -64,7 +64,7 @@ final class BatchedForkedArrayTests: XCTestCase {
             "Hello", " ", // First batch
             "World", "!"  // Second batch
         ]
-            .asyncForEach(batch: 2) { print($0) }
+            .concurrentForEach(batch: 2) { print($0) }
     }
 
     func testBatchedForkedArray_none() async throws {
@@ -82,7 +82,7 @@ final class BatchedForkedArrayTests: XCTestCase {
         let photoNames = ["one"]
         @Sendable func isValidPhoto(named: String) async -> Bool { true }
 
-        let photos = try await photoNames.asyncFilter(batch: 0, isValidPhoto(named:))
+        let photos = try await photoNames.concurrentFilter(batch: 0, isValidPhoto(named:))
 
         XCTAssertEqual(photos, photoNames)
     }
@@ -103,7 +103,7 @@ final class BatchedForkedArrayTests: XCTestCase {
         let photoNames = ["one", "two", "three"]
         @Sendable func downloadPhoto(named: String) async -> String { named }
 
-        let photos = try await photoNames.asyncMap(batch: 2, downloadPhoto(named:))
+        let photos = try await photoNames.concurrentMap(batch: 2, downloadPhoto(named:))
         XCTAssertEqual(photos, photoNames)
     }
 
@@ -125,7 +125,7 @@ final class BatchedForkedArrayTests: XCTestCase {
             return number.description
         }
 
-        let compactedArray = try await photoNames.asyncCompactMap(batch: 10, asyncFilter(number:))
+        let compactedArray = try await photoNames.concurrentCompactMap(batch: 10, asyncFilter(number:))
 
         XCTAssertEqual(compactedArray.count, photoNames.count / 2)
     }
@@ -143,7 +143,7 @@ final class BatchedForkedArrayTests: XCTestCase {
     func testBatchedForkedArraySet() async throws {
         let set = Set(0 ..< 9)
 
-        let outputArray = try await set.asyncMap(batch: 3, identity)
+        let outputArray = try await set.concurrentMap(batch: 3, identity)
 
         XCTAssertEqual(outputArray, Array(set))
     }

--- a/Tests/ForkTests/ForkCancellationTests.swift
+++ b/Tests/ForkTests/ForkCancellationTests.swift
@@ -70,7 +70,7 @@ final class ForkCancellationTests: XCTestCase, @unchecked Sendable {
         let array = Array(0..<1000)
 
         let task = Task {
-            try await array.asyncMap(batch: 10) { value -> Int in
+            try await array.concurrentMap(batch: 10) { value -> Int in
                 try await Task.sleep(for: .milliseconds(10))
                 return value * 2
             }

--- a/Tests/ForkTests/ForkEdgeCaseTests.swift
+++ b/Tests/ForkTests/ForkEdgeCaseTests.swift
@@ -10,16 +10,16 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [42]
 
         // Test with various batch sizes
-        let result1 = try await array.asyncMap(batch: 0) { $0 * 2 }
+        let result1 = try await array.concurrentMap(batch: 0) { $0 * 2 }
         XCTAssertEqual(result1, [84])
 
-        let result2 = try await array.asyncMap(batch: 1) { $0 * 2 }
+        let result2 = try await array.concurrentMap(batch: 1) { $0 * 2 }
         XCTAssertEqual(result2, [84])
 
-        let result3 = try await array.asyncMap(batch: 10) { $0 * 2 }
+        let result3 = try await array.concurrentMap(batch: 10) { $0 * 2 }
         XCTAssertEqual(result3, [84])
 
-        let result4 = try await array.asyncMap(batch: 1000) { $0 * 2 }
+        let result4 = try await array.concurrentMap(batch: 1000) { $0 * 2 }
         XCTAssertEqual(result4, [84])
     }
 
@@ -29,7 +29,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [1, 2, 3, 4, 5]
 
         // Batch size larger than array
-        let result = try await array.asyncMap(batch: 100) { $0 * 2 }
+        let result = try await array.concurrentMap(batch: 100) { $0 * 2 }
         XCTAssertEqual(result, [2, 4, 6, 8, 10])
     }
 
@@ -37,7 +37,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [1, 2, 3, 4, 5]
 
         // Batch size 0 should still work (implementation-dependent behavior)
-        let result = try await array.asyncMap(batch: 0) { $0 * 2 }
+        let result = try await array.concurrentMap(batch: 0) { $0 * 2 }
         XCTAssertEqual(result, [2, 4, 6, 8, 10])
     }
 
@@ -47,15 +47,15 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array: [Int] = []
 
         // Empty array through filter
-        let filtered = try await array.asyncFilter { $0 > 5 }
+        let filtered = try await array.concurrentFilter { $0 > 5 }
         XCTAssertEqual(filtered, [])
 
         // Empty array through map
-        let mapped = try await array.asyncMap { $0 * 2 }
+        let mapped = try await array.concurrentMap { $0 * 2 }
         XCTAssertEqual(mapped, [])
 
         // Empty array through compactMap
-        let compacted: [Int] = try await array.asyncCompactMap { $0 > 5 ? $0 : nil }
+        let compacted: [Int] = try await array.concurrentCompactMap { $0 > 5 ? $0 : nil }
         XCTAssertEqual(compacted, [])
     }
 
@@ -148,7 +148,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [1, 2, 3, 4, 5]
 
         // Filter that removes all elements
-        let result = try await array.asyncFilter { _ in false }
+        let result = try await array.concurrentFilter { _ in false }
         XCTAssertEqual(result, [])
     }
 
@@ -156,7 +156,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [1, 2, 3, 4, 5]
 
         // Filter that keeps all elements
-        let result = try await array.asyncFilter { _ in true }
+        let result = try await array.concurrentFilter { _ in true }
         XCTAssertEqual(result, [1, 2, 3, 4, 5])
     }
 
@@ -166,7 +166,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [1, 2, 3, 4, 5]
 
         // CompactMap that returns nil for all elements
-        let result: [Int] = try await array.asyncCompactMap { _ in nil }
+        let result: [Int] = try await array.concurrentCompactMap { _ in nil }
         XCTAssertEqual(result, [])
     }
 
@@ -174,7 +174,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [1, 2, 3, 4, 5]
 
         // CompactMap that returns values for all elements
-        let result: [Int] = try await array.asyncCompactMap { $0 * 2 }
+        let result: [Int] = try await array.concurrentCompactMap { $0 * 2 }
         XCTAssertEqual(result, [2, 4, 6, 8, 10])
     }
 
@@ -182,7 +182,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
         let array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
         // CompactMap that returns values for even elements only
-        let result: [Int] = try await array.asyncCompactMap { $0 % 2 == 0 ? $0 * 2 : nil }
+        let result: [Int] = try await array.concurrentCompactMap { $0 % 2 == 0 ? $0 * 2 : nil }
         XCTAssertEqual(result, [4, 8, 12, 16, 20])
     }
 
@@ -205,7 +205,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
     func testForkedArray_nestedArrays() async throws {
         let arrays = [[1, 2], [3, 4], [5, 6]]
 
-        let result = try await arrays.asyncMap { innerArray in
+        let result = try await arrays.concurrentMap { innerArray in
             innerArray.map { $0 * 2 }
         }
 
@@ -215,7 +215,7 @@ final class ForkEdgeCaseTests: XCTestCase, @unchecked Sendable {
     func testForkedArray_dictionaryValues() async throws {
         let dict = ["a": 1, "b": 2, "c": 3]
 
-        let result = try await dict.asyncMap { (key, value) in
+        let result = try await dict.concurrentMap { (key, value) in
             "\(key):\(value * 2)"
         }
 

--- a/Tests/ForkTests/ForkErrorTests.swift
+++ b/Tests/ForkTests/ForkErrorTests.swift
@@ -69,7 +69,7 @@ final class ForkErrorTests: XCTestCase, @unchecked Sendable {
         let array = Array(0..<100)
 
         do {
-            _ = try await array.asyncMap { value -> Int in
+            _ = try await array.concurrentMap { value -> Int in
                 if value == 50 {
                     throw TestError.mapFailed
                 }
@@ -87,7 +87,7 @@ final class ForkErrorTests: XCTestCase, @unchecked Sendable {
         let array = Array(0..<100)
 
         do {
-            _ = try await array.asyncFilter { value -> Bool in
+            _ = try await array.concurrentFilter { value -> Bool in
                 if value == 50 {
                     throw TestError.filterFailed
                 }
@@ -107,7 +107,7 @@ final class ForkErrorTests: XCTestCase, @unchecked Sendable {
         let array = Array(0..<100)
 
         do {
-            _ = try await array.asyncMap(batch: 10) { value -> Int in
+            _ = try await array.concurrentMap(batch: 10) { value -> Int in
                 if value == 50 {
                     throw TestError.mapFailed
                 }

--- a/Tests/ForkTests/ForkRaceConditionTests.swift
+++ b/Tests/ForkTests/ForkRaceConditionTests.swift
@@ -176,7 +176,7 @@ final class ForkRaceConditionTests: XCTestCase, @unchecked Sendable {
         let array = Array(0..<100)
 
         // Each element should be processed independently
-        try await array.asyncForEach { value in
+        try await array.concurrentForEach { value in
             await collector.append(value * 2)
         }
 

--- a/Tests/ForkTests/ForkSendableTests.swift
+++ b/Tests/ForkTests/ForkSendableTests.swift
@@ -112,7 +112,7 @@ final class ForkSendableTests: XCTestCase, @unchecked Sendable {
 
         let points = [Point(x: 1, y: 2), Point(x: 3, y: 4), Point(x: 5, y: 6)]
 
-        let result = try await points.asyncMap { point in
+        let result = try await points.concurrentMap { point in
             Point(x: point.x * 2, y: point.y * 2)
         }
 
@@ -194,7 +194,7 @@ final class ForkSendableTests: XCTestCase, @unchecked Sendable {
             Outer(inner: Inner(value: 3), name: "third")
         ]
 
-        let result = try await items.asyncMap { outer in
+        let result = try await items.concurrentMap { outer in
             Outer(inner: Inner(value: outer.inner.value * 2), name: outer.name.uppercased())
         }
 

--- a/Tests/ForkTests/ForkStressTests.swift
+++ b/Tests/ForkTests/ForkStressTests.swift
@@ -8,7 +8,7 @@ final class ForkStressTests: XCTestCase, @unchecked Sendable {
 
     func testForkedArray_largeArray_1000() async throws {
         let array = Array(0..<1_000)
-        let result = try await array.asyncMap { $0 * 2 }
+        let result = try await array.concurrentMap { $0 * 2 }
 
         XCTAssertEqual(result.count, 1_000)
         XCTAssertEqual(result[0], 0)
@@ -22,7 +22,7 @@ final class ForkStressTests: XCTestCase, @unchecked Sendable {
 
     func testForkedArray_largeArray_10000() async throws {
         let array = Array(0..<10_000)
-        let result = try await array.asyncMap { $0 * 2 }
+        let result = try await array.concurrentMap { $0 * 2 }
 
         XCTAssertEqual(result.count, 10_000)
         XCTAssertEqual(result[0], 0)
@@ -37,7 +37,7 @@ final class ForkStressTests: XCTestCase, @unchecked Sendable {
     func testForkedArray_veryLargeArray_100000() async throws {
         try await withTestTimeout(seconds: 60) {
             let array = Array(0..<100_000)
-            let result = try await array.asyncMap { $0 * 2 }
+            let result = try await array.concurrentMap { $0 * 2 }
 
             XCTAssertEqual(result.count, 100_000)
             XCTAssertEqual(result[0], 0)
@@ -56,7 +56,7 @@ final class ForkStressTests: XCTestCase, @unchecked Sendable {
         try await withTestTimeout(seconds: 60) {
             // 10,000 elements with batch size 1 = sequential processing (one batch per element)
             let array = Array(0..<10_000)
-            let result = try await array.asyncMap(batch: 1) { $0 * 2 }
+            let result = try await array.concurrentMap(batch: 1) { $0 * 2 }
 
             XCTAssertEqual(result.count, 10_000)
             XCTAssertEqual(result[0], 0)
@@ -67,7 +67,7 @@ final class ForkStressTests: XCTestCase, @unchecked Sendable {
     func testBatchedForkedArray_largeBatches() async throws {
         // 1,000 elements with batch size 1000 = single batch
         let array = Array(0..<1_000)
-        let result = try await array.asyncMap(batch: 1000) { $0 * 2 }
+        let result = try await array.concurrentMap(batch: 1000) { $0 * 2 }
 
         XCTAssertEqual(result.count, 1_000)
         for (index, value) in result.enumerated() {
@@ -192,7 +192,7 @@ final class ForkStressTests: XCTestCase, @unchecked Sendable {
     func testForkedArray_orderPreservationLargeArray() async throws {
         try await withTestTimeout(seconds: 30) {
             let array = Array(0..<10_000)
-            let result = try await array.asyncMap { $0 }
+            let result = try await array.concurrentMap { $0 }
 
             // Verify strict order preservation
             for (index, value) in result.enumerated() {
@@ -204,7 +204,7 @@ final class ForkStressTests: XCTestCase, @unchecked Sendable {
     func testBatchedForkedArray_orderPreservationLargeArray() async throws {
         try await withTestTimeout(seconds: 30) {
             let array = Array(0..<10_000)
-            let result = try await array.asyncMap(batch: 100) { $0 }
+            let result = try await array.concurrentMap(batch: 100) { $0 }
 
             // Verify strict order preservation
             for (index, value) in result.enumerated() {

--- a/Tests/ForkTests/ForkedArrayTests.swift
+++ b/Tests/ForkTests/ForkedArrayTests.swift
@@ -17,7 +17,7 @@ class ForkedArrayTests: XCTestCase {
     }
     
     func testForkedArray_ForEach() async throws {
-        try await ["Hello", " ", "World", "!"].asyncForEach { print($0) }
+        try await ["Hello", " ", "World", "!"].concurrentForEach { print($0) }
     }
     
     func testForkedArray_none() async throws {
@@ -35,7 +35,7 @@ class ForkedArrayTests: XCTestCase {
         let photoNames = ["one"]
         @Sendable func isValidPhoto(named: String) async -> Bool { true }
         
-        let photos = try await photoNames.asyncFilter(isValidPhoto(named:))
+        let photos = try await photoNames.concurrentFilter(isValidPhoto(named:))
         
         XCTAssertEqual(photos, photoNames)
     }
@@ -55,7 +55,7 @@ class ForkedArrayTests: XCTestCase {
         let photoNames = ["one", "two", "three"]
         @Sendable func downloadPhoto(named: String) async -> String { named }
         
-        let photos = try await photoNames.asyncMap(downloadPhoto(named:))
+        let photos = try await photoNames.concurrentMap(downloadPhoto(named:))
         XCTAssertEqual(photos, photoNames)
     }
     
@@ -77,7 +77,7 @@ class ForkedArrayTests: XCTestCase {
             return number.description
         }
         
-        let compactedArray = try await photoNames.asyncCompactMap(asyncFilter(number:))
+        let compactedArray = try await photoNames.concurrentCompactMap(asyncFilter(number:))
         
         XCTAssertEqual(compactedArray.count, photoNames.count / 2)
     }
@@ -95,7 +95,7 @@ class ForkedArrayTests: XCTestCase {
     func testForkedArraySet() async throws {
         let set = Set(0 ..< 9)
         
-        let outputArray = try await set.asyncMap(identity)
+        let outputArray = try await set.concurrentMap(identity)
         
         XCTAssertEqual(outputArray, Array(set))
     }


### PR DESCRIPTION
## Summary

Closes #30

- Renames `asyncMap` → `concurrentMap`, `asyncCompactMap` → `concurrentCompactMap`, `asyncFilter` → `concurrentFilter`, `asyncForEach` → `concurrentForEach` across both `Sequence+ForkedArray` and `Sequence+BatchedForkedArray` extensions
- Adds `@available(*, deprecated, renamed:)` annotations on the old methods for backwards compatibility — existing callers get a fix-it migration path
- Updates internal `BatchedForkedArray` implementation to use the new names
- Updates all tests and README to use the new `concurrent*` names

The "async" prefix was misleading because it implied serial async execution (one element at a time with suspension points), when these methods actually parallelize work across elements. The new "concurrent" prefix clearly communicates the parallel nature of these operations.

## Test plan

- [x] `swift build` passes locally
- [ ] CI runs full test suite (XCTest requires Xcode, not available in CLI-only toolchain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)